### PR TITLE
Updated compatible items to remove from drop system of Mine and Slash

### DIFF
--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/bow_bow.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/bow_bow.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/cloth_boots_boots.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/cloth_boots_boots.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/cloth_chest_chestplate.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/cloth_chest_chestplate.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/cloth_helmet_helmet.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/cloth_helmet_helmet.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/cloth_pants_leggings.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/cloth_pants_leggings.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/crossbow_crossbow.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/crossbow_crossbow.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/leather_boots_boots.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/leather_boots_boots.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/leather_chest_chestplate.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/leather_chest_chestplate.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/leather_helmet_helmet.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/leather_helmet_helmet.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/leather_pants_leggings.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/leather_pants_leggings.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/plate_boots_boots.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/plate_boots_boots.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/plate_chest_chestplate.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/plate_chest_chestplate.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/plate_helmet_helmet.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/plate_helmet_helmet.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/plate_pants_leggings.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/plate_pants_leggings.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_dagger.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_dagger.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_katana.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_katana.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_machete.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_machete.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_spear.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_spear.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },

--- a/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_sword.json
+++ b/src/main/resources/data/mmorpg/compatible_items/silentgear/sword_sword.json
@@ -9,11 +9,11 @@
   },
   "rarity": {
     "min_rarity": 0,
-    "max_rarity": 5
+    "max_rarity": 3
   },
   "misc": {
     "only_add_stats_if_loot_drop": false,
-    "add_to_loot_drops": true,
+    "add_to_loot_drops": false,
     "loot_drop_weight": 1000,
     "can_be_salvaged": false
   },


### PR DESCRIPTION
- Fixes the max rarity for the new changes in Mine and Slash.
- Removes the items from the drops of Mine and Slash by default so you have to craft to get the items. 