### PR TITLE
Support other mods using BreakSpeed event 

### DIFF
--- a/src/main/java/net/silentchaos512/gear/event/GearEvents.java
+++ b/src/main/java/net/silentchaos512/gear/event/GearEvents.java
@@ -221,7 +221,8 @@ public final class GearEvents {
             if (canHarvest) {
                 int level = TraitHelper.getTraitLevel(tool, Const.Traits.LUSTROUS);
                 int light = getLightForLustrousTrait(player.world, player.getPosition());
-                event.setNewSpeed(event.getOriginalSpeed() + getLustrousSpeedBonus(level, light));
+                //use getNewSpeed() instead of getOriginalSpeed() to support other mods that are changing the break speed with this event.
+                event.setNewSpeed(event.getNewSpeed() + getLustrousSpeedBonus(level, light));
             }
         }
     }


### PR DESCRIPTION
Support other mods that are changing the break speed with PlayerEvent.BreakSpeed event by using the getNewSpeed method instead of getOriginalSpeed

Example: My mod Useful Hats has a Mining Hat that adds speed to all pickaxes via this event. But it has no effect, because your mod overrides the new speed value after my mod set it.

In my mod there was the same problem with other mods and I fixed it on my side: https://github.com/cech12/UsefulHats/issues/22 But your mod needs also fix it to let it work. :)