### PR TITLE
New configs for tooltips

### DIFF
--- a/src/main/java/net/silentchaos512/gear/api/traits/ITrait.java
+++ b/src/main/java/net/silentchaos512/gear/api/traits/ITrait.java
@@ -18,6 +18,7 @@ import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.silentchaos512.gear.api.stats.ItemStat;
 import net.silentchaos512.gear.client.KeyTracker;
+import net.silentchaos512.gear.config.Config;
 import net.silentchaos512.gear.util.TextUtil;
 
 import javax.annotation.Nullable;
@@ -104,7 +105,7 @@ public interface ITrait {
         tooltip.add(affixFirst.apply(displayName));
 
         // Description (usually not shown)
-        if (KeyTracker.isDisplayTraitsDown()) {
+        if (KeyTracker.isDisplayTraitsDown() && !Config.Common.vanillaStyleTooltips.get()) {
             ITextComponent description = TextUtil.withColor(this.getDescription(level), TextFormatting.DARK_GRAY);
             tooltip.add(new StringTextComponent("    ").append(description));
         }

--- a/src/main/java/net/silentchaos512/gear/client/event/TooltipHandler.java
+++ b/src/main/java/net/silentchaos512/gear/client/event/TooltipHandler.java
@@ -102,17 +102,21 @@ public final class TooltipHandler {
     private static void onMaterialTooltip(ItemTooltipEvent event, ItemStack stack, MaterialInstance material) {
         boolean keyHeld = KeyTracker.isDisplayStatsDown();
 
+        if (event.getFlags().isAdvanced()) {
+            event.getToolTip().add(new StringTextComponent("Material ID: " + material.getId()).withStyle(TextFormatting.DARK_GRAY));
+            event.getToolTip().add(new StringTextComponent("Material data pack: " + material.get().getPackName()).withStyle(TextFormatting.DARK_GRAY));
+        }
+
+        if(!Config.Common.showMaterialTooltips.get()) {
+            return;
+        }
+
         if (keyHeld) {
             event.getToolTip().add(TextUtil.withColor(TextUtil.misc("tooltip.material"), Color.GOLD));
         } else {
             event.getToolTip().add(TextUtil.withColor(TextUtil.misc("tooltip.material"), Color.GOLD)
                     .append(new StringTextComponent(" ")
                             .append(TextUtil.withColor(TextUtil.keyBinding(KeyTracker.DISPLAY_STATS), TextFormatting.GRAY))));
-        }
-
-        if (event.getFlags().isAdvanced()) {
-            event.getToolTip().add(new StringTextComponent("Material ID: " + material.getId()).withStyle(TextFormatting.DARK_GRAY));
-            event.getToolTip().add(new StringTextComponent("Material data pack: " + material.get().getPackName()).withStyle(TextFormatting.DARK_GRAY));
         }
 
         if (keyHeld) {
@@ -194,13 +198,18 @@ public final class TooltipHandler {
     }
 
     private static void onPartTooltip(ItemTooltipEvent event, ItemStack stack, PartData part) {
-        // Type, tier
-        event.getToolTip().add(TextUtil.withColor(part.getType().getDisplayName(part.getTier()), Color.AQUAMARINE));
 
         if (event.getFlags().isAdvanced() && KeyTracker.isControlDown()) {
             event.getToolTip().add(new StringTextComponent("* Part ID: " + part.getId()).withStyle(TextFormatting.DARK_GRAY));
             event.getToolTip().add(new StringTextComponent("* Part data pack: " + part.get().getPackName()).withStyle(TextFormatting.DARK_GRAY));
         }
+
+        if(!Config.Common.showPartTooltips.get()) {
+            return;
+        }
+
+        // Type, tier
+        event.getToolTip().add(TextUtil.withColor(part.getType().getDisplayName(part.getTier()), Color.AQUAMARINE));
 
         // Traits
         List<TraitInstance> traits = new ArrayList<>();

--- a/src/main/java/net/silentchaos512/gear/client/util/GearClientHelper.java
+++ b/src/main/java/net/silentchaos512/gear/client/util/GearClientHelper.java
@@ -83,27 +83,31 @@ public final class GearClientHelper {
             tooltip.add(TextUtil.withColor(misc("lockedStats"), Color.YELLOW));
         }
 
-        // Let parts add information if they need to
-        Collections.reverse(constructionParts);
-        for (PartData data : constructionParts) {
-            data.get().addInformation(data, stack, tooltip, flag);
+        if (!Config.Common.vanillaStyleTooltips.get()) {
+            // Let parts add information if they need to
+            Collections.reverse(constructionParts);
+            for (PartData data : constructionParts) {
+                data.get().addInformation(data, stack, tooltip, flag);
+            }
         }
 
         // Traits
         addTraitsInfo(stack, tooltip, flag);
 
-        // Stats
-        addStatsInfo(stack, tooltip, flag, item);
+        if (!Config.Common.vanillaStyleTooltips.get()) {
+            // Stats
+            addStatsInfo(stack, tooltip, flag, item);
 
-        // Tool construction
-        if (KeyTracker.isDisplayConstructionDown() && flag.showConstruction) {
-            tooltip.add(TextUtil.withColor(misc("tooltip.construction"), Color.GOLD));
-            Collections.reverse(constructionParts);
-            tooltipListParts(stack, tooltip, constructionParts, flag);
-        } else if (flag.showConstruction) {
-            tooltip.add(TextUtil.withColor(TextUtil.misc("tooltip.construction"), Color.GOLD)
-                    .append(new StringTextComponent(" ")
-                            .append(TextUtil.withColor(TextUtil.keyBinding(KeyTracker.DISPLAY_CONSTRUCTION), TextFormatting.GRAY))));
+            // Tool construction
+            if (KeyTracker.isDisplayConstructionDown() && flag.showConstruction) {
+                tooltip.add(TextUtil.withColor(misc("tooltip.construction"), Color.GOLD));
+                Collections.reverse(constructionParts);
+                tooltipListParts(stack, tooltip, constructionParts, flag);
+            } else if (flag.showConstruction) {
+                tooltip.add(TextUtil.withColor(TextUtil.misc("tooltip.construction"), Color.GOLD)
+                        .append(new StringTextComponent(" ")
+                                .append(TextUtil.withColor(TextUtil.keyBinding(KeyTracker.DISPLAY_CONSTRUCTION), TextFormatting.GRAY))));
+            }
         }
     }
 
@@ -163,9 +167,12 @@ public final class GearClientHelper {
         }
 
         int traitIndex = getTraitDisplayIndex(visibleTraits.size(), flag);
+
         IFormattableTextComponent textTraits = TextUtil.withColor(misc("tooltip.traits"), Color.GOLD);
         if (traitIndex < 0) {
-            tooltip.add(textTraits);
+            if (!Config.Common.vanillaStyleTooltips.get()) {
+                tooltip.add(textTraits);
+            }
         }
 
         int i = 0;
@@ -173,6 +180,9 @@ public final class GearClientHelper {
             if (traitIndex < 0 || traitIndex == i) {
                 final int level = traits.get(trait);
                 trait.addInformation(level, tooltip, flag, text -> {
+                    if(Config.Common.vanillaStyleTooltips.get()) {
+                        return TextUtil.withColor(new StringTextComponent(TextListBuilder.VANILLA_BULLET + " "), Color.GRAY).append(text);
+                    }
                     if (traitIndex >= 0) {
                         return textTraits
                                 .append(TextUtil.withColor(new StringTextComponent(": "), TextFormatting.GRAY)
@@ -186,7 +196,7 @@ public final class GearClientHelper {
     }
 
     private static int getTraitDisplayIndex(int numTraits, GearTooltipFlag flag) {
-        if (KeyTracker.isDisplayTraitsDown() || numTraits == 0)
+        if (Config.Common.vanillaStyleTooltips.get() || KeyTracker.isDisplayTraitsDown() || numTraits == 0)
             return -1;
         return ClientTicks.ticksInGame() / 20 % numTraits;
     }

--- a/src/main/java/net/silentchaos512/gear/client/util/TextListBuilder.java
+++ b/src/main/java/net/silentchaos512/gear/client/util/TextListBuilder.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public class TextListBuilder {
     static final String[] BULLETS = {"\u2022", "\u25e6", "\u25aa"}; // •◦▪
+    static final String VANILLA_BULLET = "\u2666";
 
     private final List<ITextComponent> list = new ArrayList<>();
     private int indent = 0;

--- a/src/main/java/net/silentchaos512/gear/config/Config.java
+++ b/src/main/java/net/silentchaos512/gear/config/Config.java
@@ -85,6 +85,10 @@ public final class Config {
         public static final ForgeConfigSpec.BooleanValue statsDebugLogging;
         public static final ForgeConfigSpec.BooleanValue modelAndTextureLogging;
         public static final ForgeConfigSpec.BooleanValue worldGenLogging;
+        //Tooltip
+        public static final ForgeConfigSpec.BooleanValue showMaterialTooltips;
+        public static final ForgeConfigSpec.BooleanValue showPartTooltips;
+        public static final ForgeConfigSpec.BooleanValue vanillaStyleTooltips;
         // Other
         public static final ForgeConfigSpec.BooleanValue showWipText;
 
@@ -365,6 +369,18 @@ public final class Config {
             worldGenLogging = builder
                     .comment("Log details about certain features being adding to biomes and other world generator details")
                     .define("debug.logging.worldGen", true);
+
+            showMaterialTooltips = builder
+                    .comment("Show SGear Material tooltips on items that can be used as materials.")
+                    .define("tooltip.showMaterialTooltips", true);
+
+            showPartTooltips = builder
+                    .comment("Show tooltips on parts and items that can be used as parts.")
+                    .define("tooltip.showPartTooltips", true);
+
+            vanillaStyleTooltips = builder
+                    .comment("Tooltips are replaced with a simpler variant similar to vanilla and contains about as much information.")
+                    .define("tooltip.vanillaStyleTooltips", false);
 
             // Other random stuff
             showWipText = builder

--- a/src/main/java/net/silentchaos512/gear/item/CompoundMaterialItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/CompoundMaterialItem.java
@@ -20,6 +20,7 @@ import net.silentchaos512.gear.api.material.MaterialList;
 import net.silentchaos512.gear.api.part.PartType;
 import net.silentchaos512.gear.client.util.ColorUtils;
 import net.silentchaos512.gear.client.util.TextListBuilder;
+import net.silentchaos512.gear.config.Config;
 import net.silentchaos512.gear.gear.material.LazyMaterialInstance;
 import net.silentchaos512.gear.gear.material.MaterialInstance;
 import net.silentchaos512.gear.gear.material.MaterialManager;
@@ -134,16 +135,18 @@ public class CompoundMaterialItem extends Item implements IColoredMaterialItem {
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable World worldIn, List<ITextComponent> tooltip, ITooltipFlag flagIn) {
-        TextUtil.addWipText(tooltip);
+        if(Config.Common.showMaterialTooltips.get()) {
+            TextUtil.addWipText(tooltip);
 
-        Collection<IMaterialInstance> materials = getSubMaterials(stack);
+            Collection<IMaterialInstance> materials = getSubMaterials(stack);
 
-        TextListBuilder statsBuilder = new TextListBuilder();
-        for (IMaterialInstance material : materials) {
-            int nameColor = material.getNameColor(PartType.MAIN, GearType.ALL);
-            statsBuilder.add(TextUtil.withColor(material.getDisplayName(PartType.MAIN).copy(), nameColor));
+            TextListBuilder statsBuilder = new TextListBuilder();
+            for (IMaterialInstance material : materials) {
+                int nameColor = material.getNameColor(PartType.MAIN, GearType.ALL);
+                statsBuilder.add(TextUtil.withColor(material.getDisplayName(PartType.MAIN).copy(), nameColor));
+            }
+            tooltip.addAll(statsBuilder.build());
         }
-        tooltip.addAll(statsBuilder.build());
     }
 
     @Override

--- a/src/main/java/net/silentchaos512/gear/item/CompoundPartItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/CompoundPartItem.java
@@ -19,6 +19,7 @@ import net.silentchaos512.gear.api.material.MaterialList;
 import net.silentchaos512.gear.api.part.PartType;
 import net.silentchaos512.gear.client.util.ColorUtils;
 import net.silentchaos512.gear.client.util.TextListBuilder;
+import net.silentchaos512.gear.config.Config;
 import net.silentchaos512.gear.gear.material.LazyMaterialInstance;
 import net.silentchaos512.gear.gear.material.MaterialInstance;
 import net.silentchaos512.gear.gear.part.PartData;
@@ -157,7 +158,8 @@ public class CompoundPartItem extends Item {
     @Override
     public void appendHoverText(ItemStack stack, @Nullable World worldIn, List<ITextComponent> tooltip, ITooltipFlag flagIn) {
         PartData part = PartData.from(stack);
-        if (part != null) {
+
+        if (part != null && Config.Common.showPartTooltips.get()) {
             float synergy = SynergyUtils.getSynergy(this.partType, getMaterials(stack), part.getTraits());
             tooltip.add(SynergyUtils.getDisplayText(synergy));
 

--- a/src/main/java/net/silentchaos512/gear/util/GearHelper.java
+++ b/src/main/java/net/silentchaos512/gear/util/GearHelper.java
@@ -605,8 +605,11 @@ public final class GearHelper {
     public static Rarity getRarity(ItemStack stack) {
         int rarity = GearData.getStatInt(stack, ItemStats.RARITY);
         if (stack.isEnchanted())
-            rarity += 20;
-
+            if(Config.Common.vanillaStyleTooltips.get()) {
+                rarity += 80;
+            } else {
+                rarity += 20;
+            }
         if (rarity < 40)
             return Rarity.COMMON;
         if (rarity < 80)


### PR DESCRIPTION
This pull request adds three new configs for tooltips.

- Show Part Tooltips: It toggles tooltips for parts on/off.
- Show Material Tooltips: It toggles tooltips for materials.
- Vanilla Style Tooltips: This one alters the tooltips for the equipment itself to more closely mimic vanilla tools. This is disabled by default.