### PR TITLE
Fix race condition in networking code

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -20,7 +20,7 @@ authors="SilentChaos512"
     modId="forge"
     mandatory=true
     versionRange="[40.0.18,)"
-    ordering="NONE"
+    ordering="AFTER"
     side="BOTH"
 [[dependencies.silentgear]]
     modId="minecraft"


### PR DESCRIPTION
The race condition documented by nomcom in #438 still exists in the latest version.
This applies the fix suggested by Anoyomouse in the same issue.

Fixes #438 and #466