### PR TITLE
Add missing lang entry for potted netherwood sapling

### DIFF
--- a/src/main/resources/assets/silentgear/lang/en_us.json
+++ b/src/main/resources/assets/silentgear/lang/en_us.json
@@ -130,6 +130,7 @@
   "block.silentgear.orange_fluffy_block": "Orange Fluffy Block",
   "block.silentgear.phantom_light": "Phantom Light",
   "block.silentgear.pink_fluffy_block": "Pink Fluffy Block",
+  "block.silentgear.potted_netherwood_sapling": "Potted Netherwood Sapling",
   "block.silentgear.purple_fluffy_block": "Purple Fluffy Block",
   "block.silentgear.raw_azure_silver_block": "Raw Azure Silver Block",
   "block.silentgear.raw_crimson_iron_block": "Raw Crimson Iron Block",


### PR DESCRIPTION
This PR add the localized name for the potted netherwood sapling block. The translated names of blocks without block items are pretty much never used in vanilla, but mods can still get them using Block::getName (All vanilla blocks are translated even if they don't have a corresponding item)