### PR TITLE
Some fixes (1.19.3)

### DIFF
--- a/src/main/java/net/silentchaos512/gear/block/salvager/SalvagerTileEntity.java
+++ b/src/main/java/net/silentchaos512/gear/block/salvager/SalvagerTileEntity.java
@@ -135,6 +135,10 @@ public class SalvagerTileEntity extends LockableSidedInventoryTileEntity {
             }
 
             if (!copy.isEmpty()) {
+                if (copy.getTag() != null && copy.getTag().isEmpty()) {
+                    copy.setTag(null);
+                }
+
                 builder.add(copy);
             }
         }

--- a/src/main/java/net/silentchaos512/gear/block/trees/NetherwoodTree.java
+++ b/src/main/java/net/silentchaos512/gear/block/trees/NetherwoodTree.java
@@ -17,15 +17,6 @@ import net.silentchaos512.gear.init.SgBlocks;
 import org.jetbrains.annotations.Nullable;
 
 public class NetherwoodTree extends AbstractTreeGrower {
-    public static final TreeConfiguration NETHERWOOD_TREE_CONFIG = new TreeConfiguration.TreeConfigurationBuilder(
-            BlockStateProvider.simple(SgBlocks.NETHERWOOD_LOG.asBlockState()),
-            new ForkingTrunkPlacer(5, 2, 2),
-            BlockStateProvider.simple(SgBlocks.NETHERWOOD_LEAVES.asBlockState()),
-            new AcaciaFoliagePlacer(ConstantInt.of(2), ConstantInt.of(0)),
-            new TwoLayersFeatureSize(1, 0, 2))
-            .ignoreVines()
-            .build();
-    public static final Holder<ConfiguredFeature<TreeConfiguration, ?>> NETHERWOOD_TREE = Holder.direct(new ConfiguredFeature<>(Feature.TREE, NETHERWOOD_TREE_CONFIG));
     public static final ResourceKey<ConfiguredFeature<?, ?>> KEY = FeatureUtils.createKey("silentgear:netherwood");
 
     @Nullable

--- a/src/main/resources/assets/silentgear/lang/ru_ru.json
+++ b/src/main/resources/assets/silentgear/lang/ru_ru.json
@@ -324,7 +324,7 @@
   "stat.silentgear.grade.SS": "SS",
   "stat.silentgear.grade.SSS": "SSS",
   "material.silentgear.aluminum": "из алюминия",
-  "material.silentgear.amethyst": "Аметист"
+  "material.silentgear.amethyst": "Аметист",
   "material.silentgear.bismuth": "из висмута",
   "material.silentgear.blaze_gold": "из ифритного железа",
   "material.silentgear.brass": "из латуни",

--- a/src/main/resources/data/silentgear/worldgen/configured_feature/netherwood.json
+++ b/src/main/resources/data/silentgear/worldgen/configured_feature/netherwood.json
@@ -1,0 +1,51 @@
+{
+  "type": "minecraft:tree",
+  "config": {
+    "decorators": [],
+    "dirt_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "minecraft:dirt"
+      }
+    },
+    "foliage_placer": {
+      "type": "minecraft:acacia_foliage_placer",
+      "offset": 0,
+      "radius": 2
+    },
+    "foliage_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "silentgear:netherwood_leaves",
+        "Properties": {
+          "distance": "7",
+          "persistent": "false",
+          "waterlogged": "false"
+        }
+      }
+    },
+    "force_dirt": false,
+    "ignore_vines": true,
+    "minimum_size": {
+      "type": "minecraft:two_layers_feature_size",
+      "limit": 1,
+      "lower_size": 0,
+      "upper_size": 2
+    },
+    "trunk_placer": {
+      "type": "minecraft:forking_trunk_placer",
+      "base_height": 5,
+      "height_rand_a": 2,
+      "height_rand_b": 2
+    },
+    "trunk_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "silentgear:netherwood_log",
+        "Properties": {
+          "axis": "y"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes for following issues:
- Components of SG parts from salvager having empty NBT tag, preventing them from stacking with regular items (#554?)
- Netherwood trees not growing (#593) - copied vanilla acacia ConfiguredFeature json just like it was done in code before
- Russian localization not loading due to missing comma in json (#594)