### PR TITLE
Update Hoe & Mattock tool correctness

### DIFF
--- a/src/main/java/net/silentchaos512/gear/item/gear/GearHoeItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearHoeItem.java
@@ -3,6 +3,7 @@ package net.silentchaos512.gear.item.gear;
 import com.google.common.collect.Multimap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -63,7 +64,7 @@ public class GearHoeItem extends HoeItem implements ICoreTool {
 
     @Override
     public boolean isCorrectToolForDrops(ItemStack stack, BlockState state) {
-        return GearHelper.isCorrectToolForDrops(stack, state, null);
+        return GearHelper.isCorrectToolForDrops(stack, state, BlockTags.MINEABLE_WITH_HOE);
     }
 
     //region Standard tool overrides

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearMattockItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearMattockItem.java
@@ -14,6 +14,7 @@ public class GearMattockItem extends GearHoeItem {
     @Override
     public boolean isCorrectToolForDrops(ItemStack stack, BlockState state) {
         return GearHelper.isCorrectToolForDrops(stack, state, BlockTags.MINEABLE_WITH_AXE)
-                || GearHelper.isCorrectToolForDrops(stack, state, BlockTags.MINEABLE_WITH_SHOVEL);
+                || GearHelper.isCorrectToolForDrops(stack, state, BlockTags.MINEABLE_WITH_SHOVEL)
+                || GearHelper.isCorrectToolForDrops(stack, state, BlockTags.MINEABLE_WITH_HOE);
     }
 }


### PR DESCRIPTION
Update Hoe & Mattock  to be correct tool for blocks that are mineable with hoe. (fixes #655)