### PR TITLE
Update GearHelper.java

### DIFF
--- a/src/main/java/net/silentchaos512/gear/util/GearHelper.java
+++ b/src/main/java/net/silentchaos512/gear/util/GearHelper.java
@@ -579,7 +579,7 @@ public final class GearHelper {
                 : GearProperties.ATTACK_REACH.get().getBaseValue();
 
         // Also check Forge reach distance, to allow curios to add more reach
-        AttributeInstance attribute = entity.getAttribute(Attributes.BLOCK_INTERACTION_RANGE);
+        AttributeInstance attribute = entity.getAttribute(Attributes.ENTITY_INTERACTION_RANGE);
         if (attribute != null) {
             double reachBonus = attribute.getValue() - attribute.getBaseValue();
             return base + reachBonus;


### PR DESCRIPTION
Hey just wanted to let you know you're using BLOCK_INTERACTION_RANGE to determine attack range rather than ENTITY_INTERACTION_RANGE.  Found this bug when players said they could use SilentGear's weapons at range with my Fargos Talismans block range talisman which shouldn't modify entity attack range.  