### PR TITLE
fix: add isCompoundMaterial checks before deciding if grading material or gear item

### DIFF
--- a/src/main/java/net/silentchaos512/gear/block/grader/GraderBlockEntity.java
+++ b/src/main/java/net/silentchaos512/gear/block/grader/GraderBlockEntity.java
@@ -19,6 +19,7 @@ import net.silentchaos512.gear.SilentGear;
 import net.silentchaos512.gear.api.part.MaterialGrade;
 import net.silentchaos512.gear.block.SgContainerBlockEntity;
 import net.silentchaos512.gear.gear.material.MaterialInstance;
+import net.silentchaos512.gear.item.CompoundMaterialItem;
 import net.silentchaos512.gear.setup.SgBlockEntities;
 import net.silentchaos512.gear.setup.SgDataComponents;
 import net.silentchaos512.gear.setup.SgTags;
@@ -104,9 +105,12 @@ public class GraderBlockEntity extends SgContainerBlockEntity {
     }
 
     private void tryGradeItem(ItemStack input, int catalystTier) {
+
+        boolean isCompoundMaterial = input.getItem() instanceof CompoundMaterialItem;
+
         // Gear part grading
         var data = input.get(SgDataComponents.MATERIAL_LIST);
-        if (data != null) {
+        if (data != null && !isCompoundMaterial) {
             if (tryGradePartItem(input, catalystTier, data)) return;
         }
 
@@ -175,7 +179,9 @@ public class GraderBlockEntity extends SgContainerBlockEntity {
     }
 
     public static boolean canGrade(ItemStack stack) {
-        if (canGradePartItem(stack)) return true;
+        boolean isCompoundMaterial = stack.getItem() instanceof CompoundMaterialItem;
+
+        if (canGradePartItem(stack) && !isCompoundMaterial) return true;
 
         var material = MaterialInstance.from(stack);
         if (material == null) return false;
@@ -186,6 +192,11 @@ public class GraderBlockEntity extends SgContainerBlockEntity {
 
     private static boolean canGradePartItem(ItemStack stack) {
         if (!(Config.Common.graderCanGradeParts.get() || ModList.get().isLoaded("sgearmetalworks"))) {
+            return false;
+        }
+
+        // Skip for compound materials like alloy ingots
+        if (stack.getItem() instanceof CompoundMaterialItem) {
             return false;
         }
 


### PR DESCRIPTION
Fix for issue #798 - Alloy ingots incorrectly processed as parts for grading

This PR addresses a regression introduced in PR #792 where compound materials (like alloy ingots) are being processed through the part grading path instead of the material grading path. 

The issue occurs because:
- Alloy ingots use `SgDataComponents.MATERIAL_LIST` to store their component materials
- The material grader checks for this component to determine if an item is a part
- This causes alloys to be incorrectly identified as parts, resulting in their component materials being graded instead of the alloy itself

This fix:
- Adds explicit checks for `CompoundMaterialItem` in the grading logic
- Ensures compound materials bypass the part grading system regardless of config settings
- Allows alloy ingots to be graded as complete materials as intended

Note: When regrading alloys that already have graded components, the grade is properly applied to the alloy, though stackability might be affected if the underlying material lists have different structures/grades.