### PR TITLE
Bail out instead of crashing if loot table is not present in registry when applying EnchantedDropsLootTraitModifier

### DIFF
--- a/src/main/java/net/silentchaos512/gear/loot/modifier/EnchantedDropsTraitLootModifier.java
+++ b/src/main/java/net/silentchaos512/gear/loot/modifier/EnchantedDropsTraitLootModifier.java
@@ -65,11 +65,16 @@ public abstract class EnchantedDropsTraitLootModifier extends LootModifier {
         var newContext = createEnchantedLootContext(context, enchantedTool);
 
         var lootTableLookup = context.getLevel().getServer().reloadableRegistries().lookup().lookup(Registries.LOOT_TABLE).orElseThrow();
-        var lootTable = lootTableLookup.get(ResourceKey.create(Registries.LOOT_TABLE, context.getQueriedLootTableId())).orElseThrow().value();
+        var lootTableOptional = lootTableLookup.get(ResourceKey.create(Registries.LOOT_TABLE, context.getQueriedLootTableId()));
+        if (lootTableOptional.isEmpty()) {
+            return generatedLoot;
+        } else {
+            var lootTable = lootTableOptional.value();
 
-        generatedLoot.clear();
-        //noinspection deprecation
-        lootTable.getRandomItemsRaw(newContext, generatedLoot::add);
-        return generatedLoot;
+            generatedLoot.clear();
+            //noinspection deprecation
+            lootTable.getRandomItemsRaw(newContext, generatedLoot::add);
+            return generatedLoot;
+        }
     }
 }


### PR DESCRIPTION
For some more context, see this issue on Dragon Survival: https://github.com/DragonSurvivalTeam/DragonSurvival/issues/859