### PR TITLE
Synchronize Gear stat key caching to prevent CME on world load

### DIFF
--- a/src/main/java/net/silentchaos512/gear/api/util/StatGearKey.java
+++ b/src/main/java/net/silentchaos512/gear/api/util/StatGearKey.java
@@ -13,9 +13,10 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class StatGearKey {
-    private static final Map<Pair<IItemStat, GearType>, StatGearKey> CACHE = new HashMap<>();
+    private static final Map<Pair<IItemStat, GearType>, StatGearKey> CACHE = new ConcurrentHashMap<>();
 
     private final String key;
     private final IItemStat stat;


### PR DESCRIPTION
Similar to https://github.com/SilentChaos512/Silent-Gear/commit/7d9fcc690ccb36d6a6b9e77c5f2918355e1a319a and https://github.com/SilentChaos512/Silent-Gear/commit/1bf60949fc5ee2c8b8fc0b486248535378ac9034 ; I was having issues with what I assume was Mana and Artifice trying to asynchronously add new gear crashing the JEI equipment scanner, and breaking JEI and EMI on my private server for friends. I've tested the same locally, and it seemed to resolve the issue without any particular problems, so I'm offering the same fix upstream.

Relevant log:
```
[25Aug2025 22:49:55.323] [Render thread/ERROR] [net.minecraftforge.eventbus.EventBus/EVENTBUS]: Exception caught during firing event: Failed to recalculate gear properties
net.minecraft.ReportedException: Failed to recalculate gear properties
	at TRANSFORMER/silentgear@3.6.6/net.silentchaos512.gear.util.GearData.recalculateStats(GearData.java:111)
	at TRANSFORMER/silentgear@3.6.6/net.silentchaos512.gear.api.item.ICoreItem.construct(ICoreItem.java:38)
	at TRANSFORMER/silentgear@3.6.6/net.silentchaos512.gear.crafting.recipe.ShapelessGearRecipe.lambda$new$0(ShapelessGearRecipe.java:36)
	at TRANSFORMER/forge@47.4.6/net.minecraftforge.common.util.Lazy$Fast.get(Lazy.java:55)
	at TRANSFORMER/silentgear@3.6.6/net.silentchaos512.gear.crafting.recipe.ShapelessGearRecipe.m_8043_(ShapelessGearRecipe.java:77)
	at TRANSFORMER/mna@3.1.11/com.mna.api.items.ITieredItem.lambda$resolveTier$0(ITieredItem.java:61)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:196)
...
Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1230)
	at TRANSFORMER/silentgear@3.6.6/net.silentchaos512.gear.api.util.StatGearKey.of(StatGearKey.java:36)
	at TRANSFORMER/silentgear@3.6.6/net.silentchaos512.gear.util.GearData.getStatModifiers(GearData.java:295)
	at TRANSFORMER/silentgear@3.6.6/net.silentchaos512.gear.util.GearData.tryRecalculateStats(GearData.java:152)
	at TRANSFORMER/silentgear@3.6.6/net.silentchaos512.gear.util.GearData.recalculateStats(GearData.java:103)
	... 17 more
```