### PR TITLE
Fix #846: Allow damage events for armadillos to enable infestation

### DIFF
--- a/src/main/java/net/silentchaos512/gear/event/GearEvents.java
+++ b/src/main/java/net/silentchaos512/gear/event/GearEvents.java
@@ -60,6 +60,7 @@ import net.silentchaos512.gear.setup.SgRegistries;
 import net.silentchaos512.gear.setup.gear.PartTypes;
 import net.silentchaos512.gear.util.*;
 import net.silentchaos512.lib.event.ServerTicks;
+import net.minecraft.world.entity.animal.armadillo.Armadillo;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -109,7 +110,9 @@ public final class GearEvents {
         }
         event.setAmount(newIncomingDamage);
         if (newIncomingDamage < 0.0001f) {
-            event.setCanceled(true);
+            if (!(target instanceof Armadillo)) {
+                event.setCanceled(true);
+            }
         }
     }
 


### PR DESCRIPTION
Fix #846: Allow damage events for armadillos to enable infestation mechanics

When Silent Gear armor reduces incoming damage to near-zero, the damage event was being canceled entirely. This prevented armadillos with the infestation potion effect from spawning silverfish, as the game requires the damage event to fire for this mechanic to work.

This fix exempts armadillos from event cancellation when damage is reduced to zero, allowing vanilla infestation mechanics to function while preserving the damage negation benefit for players and other mobs.