### PR TITLE
Clean up IDE warnings and update deprecated API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ out
 *.iml
 .idea
 
+#vscode
+.vscode/
+
 # gradle
 build
 .gradle

--- a/src/main/java/net/silentchaos512/gear/Config.java
+++ b/src/main/java/net/silentchaos512/gear/Config.java
@@ -18,7 +18,7 @@ import net.silentchaos512.lib.util.NameUtils;
 import javax.annotation.Nullable;
 import java.util.List;
 
-@EventBusSubscriber(modid = SilentGear.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = SilentGear.MOD_ID)
 public final class Config {
     public static final class Common {
         static final ModConfigSpec SPEC;

--- a/src/main/java/net/silentchaos512/gear/SideProxy.java
+++ b/src/main/java/net/silentchaos512/gear/SideProxy.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 class SideProxy implements IProxy {
     @Nullable
     private static MinecraftServer server;
+    @SuppressWarnings("unused")
     @Nullable
     private static CreativeModeTab creativeModeTab;
 

--- a/src/main/java/net/silentchaos512/gear/api/part/MaterialGrade.java
+++ b/src/main/java/net/silentchaos512/gear/api/part/MaterialGrade.java
@@ -105,13 +105,13 @@ public enum MaterialGrade {
         return values()[val];
     }
 
-    public void setGradeOnStack(@Nonnull ItemStack stack) {
+    public void setGradeOnStack(ItemStack stack) {
         if (!stack.isEmpty()) {
             stack.set(SgDataComponents.MATERIAL_GRADE, this);
         }
     }
 
-    public ItemStack copyWithGrade(@Nonnull ItemStack stack) {
+    public ItemStack copyWithGrade(ItemStack stack) {
         ItemStack ret = stack.copy();
         setGradeOnStack(ret);
         return ret;

--- a/src/main/java/net/silentchaos512/gear/api/part/PartType.java
+++ b/src/main/java/net/silentchaos512/gear/api/part/PartType.java
@@ -1,14 +1,12 @@
 package net.silentchaos512.gear.api.part;
 
 import com.mojang.serialization.Codec;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.silentchaos512.gear.SilentGear;
 import net.silentchaos512.gear.api.item.GearType;
@@ -18,7 +16,6 @@ import net.silentchaos512.gear.api.util.PartGearKey;
 import net.silentchaos512.gear.gear.material.MaterialInstance;
 import net.silentchaos512.gear.gear.part.PartInstance;
 import net.silentchaos512.gear.item.CompoundPartItem;
-import net.silentchaos512.gear.item.MainPartItem;
 import net.silentchaos512.gear.setup.SgRegistries;
 import net.silentchaos512.gear.util.CodecUtils;
 import net.silentchaos512.lib.util.NameUtils;

--- a/src/main/java/net/silentchaos512/gear/api/property/NumberProperty.java
+++ b/src/main/java/net/silentchaos512/gear/api/property/NumberProperty.java
@@ -50,6 +50,7 @@ public class NumberProperty extends GearProperty<Float, NumberPropertyValue> {
             NumberPropertyValue::new
     );
 
+    @SuppressWarnings("unused")
     private final Operation defaultOperation;
     private final DisplayFormat displayFormat;
     private final boolean displayAsInt;

--- a/src/main/java/net/silentchaos512/gear/api/util/GearComponent.java
+++ b/src/main/java/net/silentchaos512/gear/api/util/GearComponent.java
@@ -5,11 +5,8 @@ import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.silentchaos512.gear.api.item.GearType;
 import net.silentchaos512.gear.api.part.PartType;
-import net.silentchaos512.gear.api.traits.TraitInstance;
-import net.silentchaos512.gear.setup.gear.GearProperties;
 
 import javax.annotation.Nullable;
-import java.util.Collection;
 
 public interface GearComponent<D> extends PropertyProvider<D> {
     /**

--- a/src/main/java/net/silentchaos512/gear/api/util/GearComponentInstance.java
+++ b/src/main/java/net/silentchaos512/gear/api/util/GearComponentInstance.java
@@ -7,15 +7,12 @@ import net.silentchaos512.gear.api.item.GearType;
 import net.silentchaos512.gear.api.part.PartType;
 import net.silentchaos512.gear.api.property.GearProperty;
 import net.silentchaos512.gear.api.property.GearPropertyValue;
-import net.silentchaos512.gear.api.property.TraitListProperty;
-import net.silentchaos512.gear.api.property.TraitListPropertyValue;
 import net.silentchaos512.gear.api.traits.TraitInstance;
 import net.silentchaos512.gear.setup.gear.GearProperties;
 import net.silentchaos512.gear.setup.gear.GearTypes;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Properties;
 import java.util.function.Supplier;
 
 public interface GearComponentInstance<A extends GearComponent<?>> {

--- a/src/main/java/net/silentchaos512/gear/block/ModContainerBlock.java
+++ b/src/main/java/net/silentchaos512/gear/block/ModContainerBlock.java
@@ -53,7 +53,6 @@ public abstract class ModContainerBlock<T extends BlockEntity> extends BaseEntit
         return InteractionResult.SUCCESS;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public RenderShape getRenderShape(BlockState state) {
         return RenderShape.MODEL;

--- a/src/main/java/net/silentchaos512/gear/block/alloymaker/AlloyMakerBlock.java
+++ b/src/main/java/net/silentchaos512/gear/block/alloymaker/AlloyMakerBlock.java
@@ -102,7 +102,6 @@ public class AlloyMakerBlock<R extends AlloyRecipe> extends ModContainerBlock<Al
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public BlockState rotate(BlockState state, Rotation rot) {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));

--- a/src/main/java/net/silentchaos512/gear/block/alloymaker/AlloyMakerBlockEntity.java
+++ b/src/main/java/net/silentchaos512/gear/block/alloymaker/AlloyMakerBlockEntity.java
@@ -46,6 +46,7 @@ public class AlloyMakerBlockEntity<R extends AlloyRecipe> extends SgContainerBlo
     private final AlloyMakerInfo<R> info;
     private final RecipeManager.CachedCheck<AlloyRecipeInput, R> quickCheck;
 
+    @SuppressWarnings("unused")
     private ItemStack outputItemHint = ItemStack.EMPTY;
     private int progress = 0;
     private boolean workEnabled = true;

--- a/src/main/java/net/silentchaos512/gear/block/charger/ChargerContainerMenu.java
+++ b/src/main/java/net/silentchaos512/gear/block/charger/ChargerContainerMenu.java
@@ -7,7 +7,6 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.*;
 import net.minecraft.world.item.ItemStack;
-import net.silentchaos512.gear.gear.material.MaterialInstance;
 import net.silentchaos512.gear.setup.SgMenuTypes;
 import net.silentchaos512.gear.setup.SgTags;
 import net.silentchaos512.lib.inventory.SlotOutputOnly;

--- a/src/main/java/net/silentchaos512/gear/block/charger/StarlightChargerBlock.java
+++ b/src/main/java/net/silentchaos512/gear/block/charger/StarlightChargerBlock.java
@@ -35,7 +35,6 @@ public class StarlightChargerBlock extends ModContainerBlock<ChargerBlockEntity<
         super(tileFactory, properties);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
         return SHAPE;

--- a/src/main/java/net/silentchaos512/gear/block/grader/GraderBlockEntity.java
+++ b/src/main/java/net/silentchaos512/gear/block/grader/GraderBlockEntity.java
@@ -40,6 +40,7 @@ public class GraderBlockEntity extends SgContainerBlockEntity {
     private static final int[] SLOTS_INPUT = {INPUT_SLOT, CATALYST_SLOT};
     private static final int[] SLOTS_OUTPUT = {2, 3, 4, 5};
     static final int INVENTORY_SIZE = SLOTS_INPUT.length + SLOTS_OUTPUT.length;
+    @SuppressWarnings("unused")
     private static final int[] SLOTS_ALL = IntStream.rangeClosed(0, INVENTORY_SIZE - 1).toArray();
 
     private int progress = 0;

--- a/src/main/java/net/silentchaos512/gear/block/press/MetalPressBlock.java
+++ b/src/main/java/net/silentchaos512/gear/block/press/MetalPressBlock.java
@@ -80,7 +80,6 @@ public class MetalPressBlock extends ModContainerBlock<MetalPressBlockEntity> {
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public BlockState rotate(BlockState state, Rotation rot) {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
@@ -97,7 +96,6 @@ public class MetalPressBlock extends ModContainerBlock<MetalPressBlockEntity> {
         builder.add(FACING, LIT);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
         return SHAPE;

--- a/src/main/java/net/silentchaos512/gear/block/salvager/SalvagerBlockEntity.java
+++ b/src/main/java/net/silentchaos512/gear/block/salvager/SalvagerBlockEntity.java
@@ -33,6 +33,7 @@ public class SalvagerBlockEntity extends SgContainerBlockEntity {
     private static final int INPUT_SLOT = 0;
     private static final int[] SLOTS_INPUT = {INPUT_SLOT};
     private static final int[] SLOTS_OUTPUT = IntStream.rangeClosed(1, 18).toArray();
+    @SuppressWarnings("unused")
     private static final int[] SLOTS_ALL = IntStream.rangeClosed(0, 18).toArray();
     public static final int INVENTORY_SIZE = SLOTS_INPUT.length + SLOTS_OUTPUT.length;
 

--- a/src/main/java/net/silentchaos512/gear/block/stoneanvil/StoneAnvilBlock.java
+++ b/src/main/java/net/silentchaos512/gear/block/stoneanvil/StoneAnvilBlock.java
@@ -109,7 +109,6 @@ public class StoneAnvilBlock extends BaseEntityBlock implements SimpleWaterlogge
         return SHAPE;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public RenderShape getRenderShape(BlockState pState) {
         return RenderShape.MODEL;

--- a/src/main/java/net/silentchaos512/gear/client/KeyTracker.java
+++ b/src/main/java/net/silentchaos512/gear/client/KeyTracker.java
@@ -31,7 +31,7 @@ public class KeyTracker {
 
     private static int materialCycleCount = 0;
 
-    @EventBusSubscriber(modid = SilentGear.MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(modid = SilentGear.MOD_ID, value = Dist.CLIENT)
     static final class Registration {
         @SubscribeEvent
         public static void registerKeyMappings(RegisterKeyMappingsEvent event) {

--- a/src/main/java/net/silentchaos512/gear/client/event/ExtraBlockBreakHandler.java
+++ b/src/main/java/net/silentchaos512/gear/client/event/ExtraBlockBreakHandler.java
@@ -54,6 +54,7 @@ public final class ExtraBlockBreakHandler extends SimpleJsonResourceReloadListen
         this.extraDamagedBlocks.clear();
     }
 
+    @SuppressWarnings("unused")
     private static void preRenderDamagedBlocks() {
 /*        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.DST_COLOR, GlStateManager.DestFactor.SRC_COLOR, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
         RenderSystem.enableBlend();
@@ -65,6 +66,7 @@ public final class ExtraBlockBreakHandler extends SimpleJsonResourceReloadListen
         RenderSystem.pushMatrix();*/
     }
 
+    @SuppressWarnings("unused")
     private static void postRenderDamagedBlocks() {
 /*        RenderSystem.alpha();
         RenderSystem.polygonOffset(0.0F, 0.0F);
@@ -74,6 +76,7 @@ public final class ExtraBlockBreakHandler extends SimpleJsonResourceReloadListen
         RenderSystem.popMatrix();*/
     }
 
+    @SuppressWarnings("unused")
     private void drawBlockDamageTexture(Tesselator tessellatorIn, BufferBuilder bufferBuilderIn, Entity entityIn, float partialTicks) {
 /*        double d3 = entityIn.lastTickPosX + (entityIn.getX() - entityIn.lastTickPosX) * (double) partialTicks;
         double d4 = entityIn.lastTickPosY + (entityIn.getY() - entityIn.lastTickPosY) * (double) partialTicks;
@@ -127,6 +130,7 @@ public final class ExtraBlockBreakHandler extends SimpleJsonResourceReloadListen
         }*/
     }
 
+    @SuppressWarnings("unused")
     private void cleanupExtraDamagedBlocks() {
         for (Entry<Integer, DestroyExtraBlocksProgress> entry : this.extraDamagedBlocks.entrySet()) {
             DestroyExtraBlocksProgress destroyblockprogress = entry.getValue();
@@ -178,6 +182,7 @@ public final class ExtraBlockBreakHandler extends SimpleJsonResourceReloadListen
             this.positions = positionsIn;
         }
 
+        @SuppressWarnings("unused")
         public BlockPos[] getPositions() {
             return this.positions;
         }
@@ -190,6 +195,7 @@ public final class ExtraBlockBreakHandler extends SimpleJsonResourceReloadListen
             this.partialBlockProgress = damage;
         }
 
+        @SuppressWarnings("unused")
         public int getPartialBlockDamage() {
             return this.partialBlockProgress;
         }

--- a/src/main/java/net/silentchaos512/gear/client/event/ExtraBlockBreakHandler.java
+++ b/src/main/java/net/silentchaos512/gear/client/event/ExtraBlockBreakHandler.java
@@ -161,6 +161,7 @@ public final class ExtraBlockBreakHandler extends SimpleJsonResourceReloadListen
     }
 
     private static class DestroyExtraBlocksProgress {
+        @SuppressWarnings("unused")
         private final int miningPlayerEntId;
         private final BlockPos[] positions;
         /**

--- a/src/main/java/net/silentchaos512/gear/client/event/GearHudOverlay.java
+++ b/src/main/java/net/silentchaos512/gear/client/event/GearHudOverlay.java
@@ -69,6 +69,7 @@ public class GearHudOverlay {
         }*/
     }
 
+    @SuppressWarnings("unused")
     private static boolean isEntityTargeted(@Nullable HitResult rayTraceIn) {
         return rayTraceIn != null && rayTraceIn.getType() == HitResult.Type.ENTITY;
     }

--- a/src/main/java/net/silentchaos512/gear/client/event/GearHudOverlay.java
+++ b/src/main/java/net/silentchaos512/gear/client/event/GearHudOverlay.java
@@ -16,7 +16,9 @@ public class GearHudOverlay {
     protected static final ResourceLocation GUI_ICONS_LOCATION = ResourceLocation.withDefaultNamespace("textures/gui/icons.png");
 
     private final Minecraft mc;
+    @SuppressWarnings("unused")
     private int scaledWidth;
+    @SuppressWarnings("unused")
     private int scaledHeight;
 
     public GearHudOverlay() {

--- a/src/main/java/net/silentchaos512/gear/client/event/TooltipHandler.java
+++ b/src/main/java/net/silentchaos512/gear/client/event/TooltipHandler.java
@@ -261,6 +261,7 @@ public final class TooltipHandler {
         }
     }
 
+    @SuppressWarnings("unused")
     private static int getTraitDisplayIndex(int numTraits) {
         if (!TRAIT_DISPLAY_CYCLE || KeyTracker.isControlDown() || numTraits == 0)
             return -1;

--- a/src/main/java/net/silentchaos512/gear/client/util/GearClientHelper.java
+++ b/src/main/java/net/silentchaos512/gear/client/util/GearClientHelper.java
@@ -126,6 +126,7 @@ public final class GearClientHelper {
         return Component.translatable("misc.silentgear." + key, formatArgs);
     }
 
+    @SuppressWarnings("unused")
     private static MutableComponent propertyText(String key, Object... formatArgs) {
         return Component.translatable("property.silentgear." + key, formatArgs);
     }

--- a/src/main/java/net/silentchaos512/gear/client/util/ModItemModelProperties.java
+++ b/src/main/java/net/silentchaos512/gear/client/util/ModItemModelProperties.java
@@ -8,7 +8,6 @@ import net.minecraft.world.item.CrossbowItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
-import net.silentchaos512.gear.SilentGear;
 import net.silentchaos512.gear.api.item.GearItem;
 import net.silentchaos512.gear.setup.GearItemSets;
 import net.silentchaos512.gear.setup.SgItems;

--- a/src/main/java/net/silentchaos512/gear/command/MaterialsCommand.java
+++ b/src/main/java/net/silentchaos512/gear/command/MaterialsCommand.java
@@ -153,6 +153,7 @@ public final class MaterialsCommand {
         builder.append(value).append("\t");
     }
 
+    @SuppressWarnings("unused")
     private static Component text(String key, Object... args) {
         return Component.translatable("command.silentgear.parts." + key, args);
     }

--- a/src/main/java/net/silentchaos512/gear/command/MaterialsCommand.java
+++ b/src/main/java/net/silentchaos512/gear/command/MaterialsCommand.java
@@ -35,6 +35,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public final class MaterialsCommand {
+    @SuppressWarnings("unused")
     private static final SuggestionProvider<CommandSourceStack> MATERIAL_ID_SUGGESTIONS = (ctx, builder) ->
             SharedSuggestionProvider.suggestResource(SgRegistries.MATERIAL.keySet(), builder);
 

--- a/src/main/java/net/silentchaos512/gear/command/PartsCommand.java
+++ b/src/main/java/net/silentchaos512/gear/command/PartsCommand.java
@@ -29,8 +29,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public final class PartsCommand {
+    @SuppressWarnings("unused")
     private static final SuggestionProvider<CommandSourceStack> partIdSuggestions = (ctx, builder) ->
             SharedSuggestionProvider.suggestResource(SgRegistries.PART.keySet(), builder);
+    @SuppressWarnings("unused")
     private static final SuggestionProvider<CommandSourceStack> partInGearSuggestions = (ctx, builder) -> {
         PartList parts = GearData.getConstruction(getGear(ctx)).parts();
         return SharedSuggestionProvider.suggestResource(

--- a/src/main/java/net/silentchaos512/gear/compat/curios/CurioGearItemCapability.java
+++ b/src/main/java/net/silentchaos512/gear/compat/curios/CurioGearItemCapability.java
@@ -62,6 +62,7 @@ public class CurioGearItemCapability {
 
     public static class GearCurio implements ICurio {
         private final ItemStack stack;
+        @SuppressWarnings("unused")
         private final Consumer<ItemAttributeModifiers.Builder> extraAttributes;
 
         private GearCurio() {

--- a/src/main/java/net/silentchaos512/gear/compat/jei/SGearJeiPlugin.java
+++ b/src/main/java/net/silentchaos512/gear/compat/jei/SGearJeiPlugin.java
@@ -147,6 +147,7 @@ public class SGearJeiPlugin implements IModPlugin {
         return getRecipes(recipeManager, r -> r.value().getType() == recipeType, recipeClass);
     }
 
+    @SuppressWarnings("unused")
     private static <R extends Recipe<?>> List<R> getRecipes(RecipeManager recipeManager, RecipeSerializer<?> recipeSerializer, Class<R> recipeClass) {
         return getRecipes(recipeManager, r -> r.value().getSerializer() == recipeSerializer, recipeClass);
     }
@@ -210,12 +211,14 @@ public class SGearJeiPlugin implements IModPlugin {
         reg.addIngredientInfo(stack, VanillaTypes.ITEM_STACK, Component.translatable(key));
     }
 
+    @SuppressWarnings("unused")
     private static void addInfoPage(IRecipeRegistration reg, String name, Collection<ItemLike> items) {
         String key = getDescKey(SilentGear.getId(name));
         List<ItemStack> stacks = items.stream().map(ItemStack::new).collect(Collectors.toList());
         reg.addIngredientInfo(stacks, VanillaTypes.ITEM_STACK, Component.translatable(key));
     }
 
+    @SuppressWarnings("unused")
     private static void addInfoPage(IRecipeRegistration reg, ItemLike item, Stream<ItemStack> variants) {
         String key = getDescKey(NameUtils.fromItem(item));
         reg.addIngredientInfo(variants.collect(Collectors.toList()), VanillaTypes.ITEM_STACK, Component.translatable(key));

--- a/src/main/java/net/silentchaos512/gear/compat/jei/SalvagingRecipeCategoryJei.java
+++ b/src/main/java/net/silentchaos512/gear/compat/jei/SalvagingRecipeCategoryJei.java
@@ -12,7 +12,6 @@ import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.item.ItemStack;
 import net.silentchaos512.gear.block.salvager.SalvagerScreen;
 import net.silentchaos512.gear.crafting.recipe.salvage.SalvagingRecipe;

--- a/src/main/java/net/silentchaos512/gear/crafting/ingredient/GearTypeIngredient.java
+++ b/src/main/java/net/silentchaos512/gear/crafting/ingredient/GearTypeIngredient.java
@@ -53,6 +53,7 @@ public final class GearTypeIngredient implements ICustomIngredient {
         return stack.getItem() instanceof GearItem && ((GearItem) stack.getItem()).getGearType().matches(this.type);
     }
 
+    @SuppressWarnings("unused")
     private void dissolve() {
         if (this.itemStacks == null) {
             // FIXME

--- a/src/main/java/net/silentchaos512/gear/crafting/recipe/ConversionRecipe.java
+++ b/src/main/java/net/silentchaos512/gear/crafting/recipe/ConversionRecipe.java
@@ -7,7 +7,6 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;

--- a/src/main/java/net/silentchaos512/gear/crafting/recipe/ToolActionRecipe.java
+++ b/src/main/java/net/silentchaos512/gear/crafting/recipe/ToolActionRecipe.java
@@ -5,7 +5,6 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.*;

--- a/src/main/java/net/silentchaos512/gear/crafting/recipe/smithing/CoatingSmithingRecipe.java
+++ b/src/main/java/net/silentchaos512/gear/crafting/recipe/smithing/CoatingSmithingRecipe.java
@@ -11,7 +11,6 @@ import net.neoforged.neoforge.common.CommonHooks;
 import net.silentchaos512.gear.api.item.GearType;
 import net.silentchaos512.gear.gear.material.MaterialInstance;
 import net.silentchaos512.gear.gear.part.PartInstance;
-import net.silentchaos512.gear.setup.SgDataComponents;
 import net.silentchaos512.gear.setup.SgRecipes;
 import net.silentchaos512.gear.setup.gear.PartTypes;
 import net.silentchaos512.gear.util.GearData;

--- a/src/main/java/net/silentchaos512/gear/data/DataGenerators.java
+++ b/src/main/java/net/silentchaos512/gear/data/DataGenerators.java
@@ -30,7 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber()
 public final class DataGenerators {
     private DataGenerators() {}
 

--- a/src/main/java/net/silentchaos512/gear/data/client/ModItemModelProvider.java
+++ b/src/main/java/net/silentchaos512/gear/data/client/ModItemModelProvider.java
@@ -316,6 +316,7 @@ public class ModItemModelProvider extends ItemModelProvider {
         }
     }
 
+    @SuppressWarnings("unused")
     private ItemModelBuilder tempGear(DeferredItem<? extends GearItem> item, ModelFile parent) {
         String name = gearTypeName(item.get().getGearType());
         return getBuilder(item.getId().getPath())

--- a/src/main/java/net/silentchaos512/gear/data/loot/ModEntityLootTables.java
+++ b/src/main/java/net/silentchaos512/gear/data/loot/ModEntityLootTables.java
@@ -95,7 +95,8 @@ public class ModEntityLootTables extends EntityLootSubProvider {
                 );
     }
 
-    private static void heroOfTheVillage(BiConsumer<ResourceLocation, LootTable.Builder> consumer, ResourceLocation tableName, ItemLike... items) {
+    @SuppressWarnings("unused")
+private static void heroOfTheVillage(BiConsumer<ResourceLocation, LootTable.Builder> consumer, ResourceLocation tableName, ItemLike... items) {
         LootPool.Builder pool = LootPool.lootPool()
                 .setRolls(ConstantValue.exactly(1));
         for (ItemLike item : items) {

--- a/src/main/java/net/silentchaos512/gear/data/recipes/ToolActionRecipeBuilder.java
+++ b/src/main/java/net/silentchaos512/gear/data/recipes/ToolActionRecipeBuilder.java
@@ -4,7 +4,6 @@ import net.minecraft.advancements.Criterion;
 import net.minecraft.data.recipes.RecipeBuilder;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;

--- a/src/main/java/net/silentchaos512/gear/data/tags/ModEntityTypeTagsProvider.java
+++ b/src/main/java/net/silentchaos512/gear/data/tags/ModEntityTypeTagsProvider.java
@@ -1,13 +1,9 @@
 package net.silentchaos512.gear.data.tags;
 
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.IntrinsicHolderTagsProvider;
-import net.minecraft.data.tags.TagsProvider;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.EntityType;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import net.silentchaos512.gear.SilentGear;
@@ -16,7 +12,6 @@ import net.silentchaos512.gear.setup.SgTags;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 public class ModEntityTypeTagsProvider extends IntrinsicHolderTagsProvider<EntityType<?>> {
     public ModEntityTypeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, @Nullable ExistingFileHelper existingFileHelper) {

--- a/src/main/java/net/silentchaos512/gear/event/GearEvents.java
+++ b/src/main/java/net/silentchaos512/gear/event/GearEvents.java
@@ -60,7 +60,6 @@ import net.silentchaos512.gear.setup.SgRegistries;
 import net.silentchaos512.gear.setup.gear.PartTypes;
 import net.silentchaos512.gear.util.*;
 import net.silentchaos512.lib.event.ServerTicks;
-import net.minecraft.world.entity.animal.armadillo.Armadillo;
 
 import javax.annotation.Nullable;
 import java.util.Collections;

--- a/src/main/java/net/silentchaos512/gear/event/ServerEvents.java
+++ b/src/main/java/net/silentchaos512/gear/event/ServerEvents.java
@@ -9,8 +9,6 @@ import net.neoforged.neoforge.event.OnDatapackSyncEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.silentchaos512.gear.SilentGear;
-import net.silentchaos512.gear.gear.material.MaterialManager;
-import net.silentchaos512.gear.gear.part.PartManager;
 import net.silentchaos512.gear.network.payload.server.SyncMaterialsPayload;
 import net.silentchaos512.gear.network.payload.server.SyncPartsPayload;
 import net.silentchaos512.gear.network.payload.server.SyncTraitsPayload;

--- a/src/main/java/net/silentchaos512/gear/gear/material/modifier/ChargedMaterialModifier.java
+++ b/src/main/java/net/silentchaos512/gear/gear/material/modifier/ChargedMaterialModifier.java
@@ -16,7 +16,6 @@ import net.silentchaos512.gear.api.util.ChargedProperties;
 import net.silentchaos512.gear.gear.material.MaterialInstance;
 import net.silentchaos512.gear.setup.SgDataComponents;
 import net.silentchaos512.gear.setup.gear.GearProperties;
-import net.silentchaos512.gear.setup.gear.MaterialModifiers;
 import net.silentchaos512.gear.setup.gear.PartTypes;
 import net.silentchaos512.gear.util.Const;
 

--- a/src/main/java/net/silentchaos512/gear/gear/part/PartInstance.java
+++ b/src/main/java/net/silentchaos512/gear/gear/part/PartInstance.java
@@ -46,6 +46,7 @@ public final class PartInstance implements GearComponentInstance<GearPart> {
             PartInstance::new
     );
 
+    @SuppressWarnings("unused")
     private static final Map<ResourceLocation, PartInstance> CACHE_UNGRADED_PARTS = new HashMap<>();
 
     private final DataResource<GearPart> part;

--- a/src/main/java/net/silentchaos512/gear/gear/trait/effect/SelfRepairTraitEffect.java
+++ b/src/main/java/net/silentchaos512/gear/gear/trait/effect/SelfRepairTraitEffect.java
@@ -7,7 +7,6 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.entity.player.Player;
 import net.silentchaos512.gear.api.traits.TraitActionContext;
 import net.silentchaos512.gear.api.traits.TraitEffect;
 import net.silentchaos512.gear.api.traits.TraitEffectType;

--- a/src/main/java/net/silentchaos512/gear/item/CompoundMaterialItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/CompoundMaterialItem.java
@@ -6,7 +6,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.silentchaos512.gear.SilentGear;
 import net.silentchaos512.gear.api.traits.TraitInstance;
-import net.silentchaos512.gear.api.util.PartGearKey;
 import net.silentchaos512.gear.api.util.PropertyKey;
 import net.silentchaos512.gear.client.util.ColorUtils;
 import net.silentchaos512.gear.client.util.TextListBuilder;
@@ -19,7 +18,6 @@ import net.silentchaos512.gear.setup.gear.GearTypes;
 import net.silentchaos512.gear.setup.gear.PartTypes;
 import net.silentchaos512.gear.util.SynergyUtils;
 import net.silentchaos512.gear.util.TextUtil;
-import net.silentchaos512.gear.util.TraitHelper;
 import net.silentchaos512.lib.util.NameUtils;
 
 import javax.annotation.Nullable;

--- a/src/main/java/net/silentchaos512/gear/item/CompoundPartItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/CompoundPartItem.java
@@ -2,7 +2,6 @@ package net.silentchaos512.gear.item;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;

--- a/src/main/java/net/silentchaos512/gear/item/RepairKitItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/RepairKitItem.java
@@ -64,6 +64,7 @@ public class RepairKitItem extends Item {
         return efficiency.get().floatValue() + repairType.getBonusEfficiency();
     }
 
+    @SuppressWarnings("unused")
     private static float getStoredAmount(ItemStack stack, MaterialInstance material) {
         var materialStorage = stack.get(SgDataComponents.MATERIAL_STORAGE);
         return materialStorage != null ? materialStorage.getOrDefault(material, 0f) : 0f;

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearArmorItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearArmorItem.java
@@ -37,6 +37,7 @@ import java.util.function.Supplier;
 
 public class GearArmorItem extends ArmorItem implements GearArmor {
     // Caches armor colors by model key to speed up armor rendering
+    @SuppressWarnings("unused")
     private static final Cache<String, Integer> ARMOR_COLORS = CacheBuilder.newBuilder()
             .maximumSize(1000)
             .expireAfterWrite(5, TimeUnit.MINUTES)

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearArmorItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearArmorItem.java
@@ -91,6 +91,7 @@ public class GearArmorItem extends ArmorItem implements GearArmor {
         return 0;
     }
 
+    @SuppressWarnings("unused")
     private static int getPlayerTotalArmorValue(LivingEntity player) {
         float total = 0;
         for (ItemStack armor : player.getArmorSlots()) {

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearCrossbowItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearCrossbowItem.java
@@ -32,7 +32,9 @@ public class GearCrossbowItem extends CrossbowItem implements GearRangedWeapon {
     private static final int MIN_CHARGE_TIME = 5;
     private static final int MAX_CHARGE_TIME = 50;
 
+    @SuppressWarnings("unused")
     private boolean startSoundPlayed = false;
+    @SuppressWarnings("unused")
     private boolean midLoadSoundPlayed = false;
 
     private final Supplier<GearType> gearType;

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearHammerItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearHammerItem.java
@@ -1,6 +1,5 @@
 package net.silentchaos512.gear.item.gear;
 
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ClipContext;

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearPickaxeItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearPickaxeItem.java
@@ -22,7 +22,6 @@ import net.silentchaos512.gear.api.item.GearDiggerTool;
 import net.silentchaos512.gear.api.item.GearType;
 import net.silentchaos512.gear.client.util.GearClientHelper;
 import net.silentchaos512.gear.core.component.GearPropertiesData;
-import net.silentchaos512.gear.setup.GearItemSets;
 import net.silentchaos512.gear.setup.SgTags;
 import net.silentchaos512.gear.util.Const;
 import net.silentchaos512.gear.util.GearData;

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearSlingshotItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearSlingshotItem.java
@@ -19,6 +19,7 @@ public class GearSlingshotItem extends GearBowItem {
     /**
      * Extra damage added by "power" enchantment. Bows are 0.5.
      */
+    @SuppressWarnings("unused")
     private static final float POWER_SCALE = 0.35f;
 
     public GearSlingshotItem(Supplier<GearType> gearType) {

--- a/src/main/java/net/silentchaos512/gear/network/SgNetwork.java
+++ b/src/main/java/net/silentchaos512/gear/network/SgNetwork.java
@@ -8,7 +8,7 @@ import net.silentchaos512.gear.SilentGear;
 import net.silentchaos512.gear.network.payload.client.*;
 import net.silentchaos512.gear.network.payload.server.*;
 
-@EventBusSubscriber(modid = SilentGear.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = SilentGear.MOD_ID)
 public final class SgNetwork {
     @SubscribeEvent
     public static void register(RegisterPayloadHandlersEvent event) {

--- a/src/main/java/net/silentchaos512/gear/network/payload/server/SyncMaterialsPayload.java
+++ b/src/main/java/net/silentchaos512/gear/network/payload/server/SyncMaterialsPayload.java
@@ -7,7 +7,6 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.silentchaos512.gear.SilentGear;
 import net.silentchaos512.gear.api.material.Material;
-import net.silentchaos512.gear.api.material.MaterialSerializer;
 import net.silentchaos512.gear.gear.material.MaterialSerializers;
 import net.silentchaos512.gear.setup.SgRegistries;
 

--- a/src/main/java/net/silentchaos512/gear/setup/NerfedGear.java
+++ b/src/main/java/net/silentchaos512/gear/setup/NerfedGear.java
@@ -30,7 +30,12 @@ public final class NerfedGear {
     private NerfedGear() {}
 
     public static void init() {
-        /*Field maxDamageField;
+        // _nerfDurabilityTest();
+    }
+
+    @SuppressWarnings("unused")
+    private static void _nerfDurabilityTest() {
+        Field maxDamageField;
         try {
             maxDamageField = ObfuscationReflectionHelper.findField(Item.class, "f_41371_");
             maxDamageField.setAccessible(true);
@@ -51,7 +56,7 @@ public final class NerfedGear {
                     e.printStackTrace();
                 }
             }
-        }*/
+        }
     }
 
     private static boolean isNerfedItem(Item item) {

--- a/src/main/java/net/silentchaos512/gear/setup/SgBlockEntities.java
+++ b/src/main/java/net/silentchaos512/gear/setup/SgBlockEntities.java
@@ -108,7 +108,7 @@ public final class SgBlockEntities {
     }
 
     @OnlyIn(Dist.CLIENT)
-    @EventBusSubscriber(value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(value = Dist.CLIENT)
     public static class ClientEvents {
         @SubscribeEvent
         public static void registerRenderers(EntityRenderersEvent.RegisterRenderers event) {

--- a/src/main/java/net/silentchaos512/gear/setup/SgBlocks.java
+++ b/src/main/java/net/silentchaos512/gear/setup/SgBlocks.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-@EventBusSubscriber(modid = SilentGear.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = SilentGear.MOD_ID)
 public final class SgBlocks {
     public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(SilentGear.MOD_ID);
 

--- a/src/main/java/net/silentchaos512/gear/setup/SgDataComponents.java
+++ b/src/main/java/net/silentchaos512/gear/setup/SgDataComponents.java
@@ -2,6 +2,7 @@ package net.silentchaos512.gear.setup;
 
 import com.mojang.serialization.Codec;
 import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.Unit;
@@ -22,7 +23,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class SgDataComponents {
-    public static final DeferredRegister.DataComponents REGISTRAR = DeferredRegister.createDataComponents(SilentGear.MOD_ID);
+    public static final DeferredRegister.DataComponents REGISTRAR = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, SilentGear.MOD_ID);
 
     public static final Supplier<DataComponentType<ItemContainerContents>> CONTAINED_ITEMS = REGISTRAR.registerComponentType(
             "contained_items",

--- a/src/main/java/net/silentchaos512/gear/setup/SgDataComponents.java
+++ b/src/main/java/net/silentchaos512/gear/setup/SgDataComponents.java
@@ -11,7 +11,6 @@ import net.silentchaos512.gear.SilentGear;
 import net.silentchaos512.gear.api.material.Material;
 import net.silentchaos512.gear.api.part.MaterialGrade;
 import net.silentchaos512.gear.api.part.PartType;
-import net.silentchaos512.gear.api.property.GearPropertyMap;
 import net.silentchaos512.gear.api.util.DataResource;
 import net.silentchaos512.gear.core.component.GearConstructionData;
 import net.silentchaos512.gear.core.component.GearPropertiesData;

--- a/src/main/java/net/silentchaos512/gear/setup/SgEntities.java
+++ b/src/main/java/net/silentchaos512/gear/setup/SgEntities.java
@@ -58,7 +58,7 @@ public final class SgEntities {
                 .build(SilentGear.getId(name).toString()));
     }
 
-    @EventBusSubscriber(value = Dist.CLIENT, modid = SilentGear.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(value = Dist.CLIENT, modid = SilentGear.MOD_ID)
     public static class Events {
         @OnlyIn(Dist.CLIENT)
         @SubscribeEvent

--- a/src/main/java/net/silentchaos512/gear/setup/SgEntities.java
+++ b/src/main/java/net/silentchaos512/gear/setup/SgEntities.java
@@ -1,19 +1,14 @@
 package net.silentchaos512.gear.setup;
 
 import net.minecraft.client.renderer.entity.FishingHookRenderer;
-import net.minecraft.client.renderer.item.ItemProperties;
-import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
-import net.minecraft.world.item.Item;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
@@ -29,7 +24,6 @@ import net.silentchaos512.gear.entity.GearFishingHook;
 import net.silentchaos512.gear.entity.projectile.GearArrowEntity;
 import net.silentchaos512.gear.entity.projectile.GearTridentProjectile;
 import net.silentchaos512.gear.entity.projectile.SlingshotProjectile;
-import net.silentchaos512.gear.item.gear.GearTridentItem;
 
 public final class SgEntities {
     public static final DeferredRegister<EntityType<?>> ENTITIES = DeferredRegister.create(BuiltInRegistries.ENTITY_TYPE, SilentGear.MOD_ID);

--- a/src/main/java/net/silentchaos512/gear/setup/SgMenuTypes.java
+++ b/src/main/java/net/silentchaos512/gear/setup/SgMenuTypes.java
@@ -113,7 +113,7 @@ public final class SgMenuTypes {
     }
 
     @OnlyIn(Dist.CLIENT)
-    @EventBusSubscriber(value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(value = Dist.CLIENT)
     public static class ClientEvents {
         @SubscribeEvent
         public static void registerScreens(RegisterMenuScreensEvent event) {

--- a/src/main/java/net/silentchaos512/gear/setup/SgRegistries.java
+++ b/src/main/java/net/silentchaos512/gear/setup/SgRegistries.java
@@ -21,7 +21,7 @@ import net.silentchaos512.gear.gear.part.PartManager;
 import net.silentchaos512.gear.gear.trait.TraitManager;
 import org.jetbrains.annotations.NotNull;
 
-@EventBusSubscriber(modid = SilentGear.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = SilentGear.MOD_ID)
 public class SgRegistries {
     public static final ResourceKey<Registry<GearType>> GEAR_TYPE_KEY = createRegistryKey("gear_type");
     public static final ResourceKey<Registry<PartType>> PART_TYPE_KEY = createRegistryKey("part_type");

--- a/src/main/java/net/silentchaos512/gear/setup/gear/PartTypes.java
+++ b/src/main/java/net/silentchaos512/gear/setup/gear/PartTypes.java
@@ -6,7 +6,6 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.silentchaos512.gear.SilentGear;
 import net.silentchaos512.gear.api.part.PartType;
-import net.silentchaos512.gear.item.CompoundPartItem;
 import net.silentchaos512.gear.item.MainPartItem;
 import net.silentchaos512.gear.setup.SgItems;
 import net.silentchaos512.gear.setup.SgRegistries;

--- a/src/main/java/net/silentchaos512/gear/util/CodecUtils.java
+++ b/src/main/java/net/silentchaos512/gear/util/CodecUtils.java
@@ -10,7 +10,6 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.RegistrationInfo;
 import net.minecraft.core.Registry;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;

--- a/src/main/java/net/silentchaos512/gear/util/CodecUtils.java
+++ b/src/main/java/net/silentchaos512/gear/util/CodecUtils.java
@@ -88,7 +88,7 @@ public class CodecUtils {
         );
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings("unchecked")
     private static <T> DataResult<Holder.Reference<T>> safeCastToReference(Registry<T> registry, Holder<T> p_326365_) {
         return p_326365_.getDelegate() instanceof Holder.Reference reference
                 ? DataResult.success(reference)

--- a/src/main/java/net/silentchaos512/gear/util/GearData.java
+++ b/src/main/java/net/silentchaos512/gear/util/GearData.java
@@ -254,6 +254,7 @@ public final class GearData {
         return new GearPropertiesData(finalValues);
     }
 
+    @SuppressWarnings("unused")
     private static void modifyEnchantmentData(ItemStack gear, @Nullable Player player) {
         final var playersItemText = getPlayersItemNameText(gear, player);
 

--- a/src/main/java/net/silentchaos512/gear/util/GearHelper.java
+++ b/src/main/java/net/silentchaos512/gear/util/GearHelper.java
@@ -40,7 +40,6 @@ import net.silentchaos512.gear.api.item.GearItem;
 import net.silentchaos512.gear.api.item.GearTool;
 import net.silentchaos512.gear.api.item.GearType;
 import net.silentchaos512.gear.api.material.Material;
-import net.silentchaos512.gear.api.part.GearPart;
 import net.silentchaos512.gear.api.part.PartList;
 import net.silentchaos512.gear.api.part.PartType;
 import net.silentchaos512.gear.api.property.NumberProperty;

--- a/src/main/java/net/silentchaos512/gear/util/GearHelper.java
+++ b/src/main/java/net/silentchaos512/gear/util/GearHelper.java
@@ -691,6 +691,7 @@ public final class GearHelper {
         items.add(createSampleItem(item, Const.Materials.TYRIAN_STEEL));
     }
 
+    @SuppressWarnings("unused")
     private static ItemStack createSampleItem(GearItem item, int tier) {
         ItemStack result = GearGenerator.create(item);
         if (result.isEmpty()) {


### PR DESCRIPTION
## Summary
- Remove unused imports and fields
- Remove redundant @NotNull annotations
- Remove unnecessary @SuppressWarnings annotations
- Add @SuppressWarnings for intentionally unused methods/fields
- Fix deprecated DeferredRegister.createDataComponents() usage
- Remove deprecated bus parameter from @EventBusSubscriber
- Add .vscode/ to gitignore

No functional changes - just code cleanup for maintainability.

## Deprecation Fix References
DeferredRegister.createDataComponents:
- Changed from DeferredRegister.createDataComponents(modId) to DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, modId)
- Scheduled for removal in 1.21.2
- Docs: https://docs.neoforged.net/docs/concepts/registries/ | https://aldak.netlify.app/javadoc/1.21.1-21.1.x/deprecated-list

@EventBusSubscriber bus parameter:
- Removed bus = EventBusSubscriber.Bus.MOD - NeoForge now auto-routes events based on whether the event implements IModBusEvent
- Docs: https://docs.neoforged.net/docs/concepts/events/