### PR TITLE
Fixes #755, random gear crash when harvest speed is 0 or NaN

### DIFF
--- a/src/main/java/net/silentchaos512/gear/api/item/GearDiggerTool.java
+++ b/src/main/java/net/silentchaos512/gear/api/item/GearDiggerTool.java
@@ -21,7 +21,8 @@ public interface GearDiggerTool extends GearTool {
 
     @Override
     default Tool createToolProperties(GearPropertiesData properties) {
-        var harvestSpeed = properties.getNumber(GearProperties.HARVEST_SPEED);
+        var rawSpeed = properties.getNumber(GearProperties.HARVEST_SPEED);
+        var harvestSpeed = Float.isNaN(rawSpeed) || rawSpeed < 0.1f ? 0.1f : rawSpeed;
         var harvestTier = properties.getOrDefault(GearProperties.HARVEST_TIER, new HarvestTierPropertyValue(HarvestTier.ZERO));
         return new Tool(
                 List.of(

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearMacheteItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearMacheteItem.java
@@ -57,7 +57,8 @@ public class GearMacheteItem extends GearSwordItem implements BreakEventHandler,
     @Override
     public Tool createToolProperties(GearPropertiesData properties) {
         // Works like both a sword and an axe
-        var harvestSpeed = properties.getNumber(GearProperties.HARVEST_SPEED);
+        var rawSpeed = properties.getNumber(GearProperties.HARVEST_SPEED);
+        var harvestSpeed = Float.isNaN(rawSpeed) || rawSpeed < 0.1f ? 0.1f : rawSpeed;
         var harvestTier = properties.getOrDefault(GearProperties.HARVEST_TIER, new HarvestTierPropertyValue(HarvestTier.ZERO));
         return new Tool(
                 List.of(

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearShearsItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearShearsItem.java
@@ -46,7 +46,9 @@ public class GearShearsItem extends ShearsItem implements GearTool {
     @Override
     public Tool createToolProperties(GearPropertiesData properties) {
         // Mimic ShearsItem. Adjust speed so that iron shears are identical to vanilla.
-        final float adjustedSpeed = properties.getNumber(GearProperties.HARVEST_SPEED) / 6f;
+        var rawSpeed = properties.getNumber(GearProperties.HARVEST_SPEED);
+        var harvestSpeed = Float.isNaN(rawSpeed) || rawSpeed < 0.1f ? 0.1f : rawSpeed;
+        final float adjustedSpeed = harvestSpeed / 6f;
         return new Tool(
                 List.of(
                         Tool.Rule.minesAndDrops(List.of(Blocks.COBWEB), 15f * adjustedSpeed),


### PR DESCRIPTION
## Summary
Random gear generation with custom material datapacks could produce harvest speeds of 0 or NaN, causing crashes when saving items to NBT.

## Root Cause
Minecraft's `Tool.Rule` codec uses `ExtraCodecs.POSITIVE_FLOAT` for the speed field, which requires values > 0.0:

```java
// net/minecraft/util/ExtraCodecs.java
public static final Codec<Float> POSITIVE_FLOAT = floatRangeMinExclusiveWithMessage(
    0.0F, Float.MAX_VALUE, p_339597_ -> "Value must be positive: " + p_339597_
);

// net/minecraft/world/item/component/Tool.java  
ExtraCodecs.POSITIVE_FLOAT.optionalFieldOf("speed").forGetter(Tool.Rule::speed)
```

## Fix
Added minimum 0.1f clamp and NaN check to all Tool creation paths:
- `GearDiggerTool.createToolProperties`
- `GearMacheteItem.createToolProperties`
- `GearShearsItem.createToolProperties`

Fixes #755