### PR TITLE
Fixes #886, prevent tooltip OOB crash in UpgradeGearPart

### DIFF
--- a/src/main/java/net/silentchaos512/gear/gear/part/UpgradeGearPart.java
+++ b/src/main/java/net/silentchaos512/gear/gear/part/UpgradeGearPart.java
@@ -52,7 +52,8 @@ public class UpgradeGearPart extends CoreGearPart {
 
     @Override
     public void addInformation(PartInstance part, ItemStack gear, List<Component> tooltip, TooltipFlag flag) {
-        tooltip.add(1, part.getDisplayName(this.partType));
+        int idx = Math.min(1, tooltip.size());
+        tooltip.add(idx, part.getDisplayName(this.partType));
     }
 
     @Override


### PR DESCRIPTION
### Summary
This PR prevents a client crash when hovering the crafting output for certain upgrade combinations (e.g., Hammer/Excavator + upgrade item).  
The crash was caused by inserting a tooltip line at a fixed index (`add(1, ...)`) while the tooltip list can be empty in some UI contexts.

### Details
- Observed on **MC 1.21.11 / NeoForge 21.11.38-beta** that the `ItemTooltipEvent` can be fired with an **empty tooltip list** (`size == 0`) for crafting output preview.
- `UpgradeGearPart.addInformation` assumed the tooltip list is non-empty and attempted `tooltip.add(1, ...)`, leading to `IndexOutOfBoundsException`.
- This change clamps the insertion index using `Math.min(1, tooltip.size())`:
  - Preserves the original intent
  - Avoids OOB when the tooltip list is empty

Fixes #886