### PR TITLE
Refs #888: set DYED_COLOR for gear armor to fix tint on dyeable equip…

### DIFF
--- a/src/main/java/net/silentchaos512/gear/item/gear/GearArmorItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearArmorItem.java
@@ -61,6 +61,12 @@ public class GearArmorItem extends BasicGearItem implements GearArmor {
                             .setAsset(equippableInfo.assetId())
                             .build()
             );
+
+            int color = GearArmorItem.getArmorColor(gear);
+            gear.set(
+                    DataComponents.DYED_COLOR,
+                    new DyedItemColor(color)
+            );
         }
     }
 


### PR DESCRIPTION
Related to #888

This PR fixes the **armor tint** issue by ensuring `DataComponents.DYED_COLOR` is set for dyeable equipment assets (e.g. `generic_shiny`), so material colors render correctly.

**Note:** #888 also tracks a separate issue: missing resource  
`silentgear:textures/entity/equipment/humanoid_leggings/generic_shiny_overlay.png`  
That file is still missing from the mod resources and needs to be added separately (not addressed by this PR).