### PR TITLE
Fixes #900, prevent dedicated server crash when resolving material si…

### DIFF
--- a/src/main/java/net/silentchaos512/gear/gear/material/AbstractMaterial.java
+++ b/src/main/java/net/silentchaos512/gear/gear/material/AbstractMaterial.java
@@ -1,7 +1,6 @@
 package net.silentchaos512.gear.gear.material;
 
 import com.google.common.collect.Sets;
-import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;
@@ -182,9 +181,7 @@ public abstract class AbstractMaterial implements Material {
         if (name.getContents() instanceof TranslatableContents translatableContents) {
             var key = translatableContents.getKey();
             var simpleNameKey = key + ".simple";
-            if (I18n.exists(simpleNameKey)) {
-                return Component.translatable(simpleNameKey);
-            }
+            return Component.translatableWithFallback(simpleNameKey, "%s", name);
         }
         return name;
     }


### PR DESCRIPTION
## Summary

This fixes a dedicated-server crash in the material simple-name path introduced in 4.1.6.

`AbstractMaterial#getSimpleName` was using the client-only `net.minecraft.client.resources.language.I18n` class to check whether a `.simple` translation key existed. That works on the client, but on a dedicated server it can be reached while:

- recalculating existing gear data during player login
- constructing gear from compound materials during crafting

When that happened, the server threw `NoClassDefFoundError: net/minecraft/client/resources/language/I18n`, which could either prevent affected gear from being crafted or prevent a player from being placed in the world.

## Changes

- remove the client-only `I18n.exists(...)` check from `AbstractMaterial#getSimpleName`
- replace it with a server-safe translatable fallback
- preserve localized material names by using `Component.translatableWithFallback(simpleNameKey, "%s", name)` instead of flattening the original component to a raw string

## Testing

- manually reproduced the issue on a dedicated server with compound-material gear crafting
- verified that the previous exception no longer occurs after this change

Fixes #900