### PR TITLE
Fix alloy maker automation rejecting valid custom recipe inputs

### DIFF
--- a/src/main/java/net/silentchaos512/gear/block/alloymaker/AlloyMakerBlockEntity.java
+++ b/src/main/java/net/silentchaos512/gear/block/alloymaker/AlloyMakerBlockEntity.java
@@ -20,6 +20,7 @@ import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.ItemStackHandler;
 import net.silentchaos512.gear.SilentGear;
 import net.silentchaos512.gear.api.material.Material;
@@ -44,6 +45,7 @@ public class AlloyMakerBlockEntity<R extends AlloyRecipe> extends SgContainerBlo
 
     private final AlloyMakerInfo<R> info;
     private final RecipeManager.CachedCheck<AlloyRecipeInput, R> quickCheck;
+    private final IItemHandler automationItemHandler;
 
     private ItemStack outputItemHint = ItemStack.EMPTY;
     private int progress = 0;
@@ -81,6 +83,7 @@ public class AlloyMakerBlockEntity<R extends AlloyRecipe> extends SgContainerBlo
         super(info.getBlockEntityType(), pos, state, info.getInputSlotCount() + 2, () -> createItemHandler(info));
         this.info = info;
         this.quickCheck = RecipeManager.createCheck(info.getRecipeType());
+        this.automationItemHandler = createAutomationItemHandler();
     }
 
     protected RecipeType<R> getRecipeType() {
@@ -302,7 +305,32 @@ public class AlloyMakerBlockEntity<R extends AlloyRecipe> extends SgContainerBlo
 
     @Override
     public boolean canPlaceItem(int index, ItemStack stack) {
-        return index < getInputSlotCount();
+        return index >= 0 && index < getInputSlotCount() && acceptsInput(stack);
+    }
+
+    private boolean acceptsInput(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return false;
+        }
+
+        var material = MaterialInstance.from(stack);
+        if (material != null && this.info.acceptsMaterial(material)) {
+            return true;
+        }
+
+        if (this.level == null) {
+            return false;
+        }
+
+        for (var recipeHolder : this.level.getRecipeManager().getAllRecipesFor(getRecipeType())) {
+            for (var ingredient : recipeHolder.value().getIngredients()) {
+                if (ingredient.test(stack)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     @Override
@@ -323,12 +351,8 @@ public class AlloyMakerBlockEntity<R extends AlloyRecipe> extends SgContainerBlo
         return new ItemStackHandler(totalSlots) {
             @Override
             public boolean isItemValid(int slot, ItemStack stack) {
-                // Only materials in the correct categories are accepted
-                if (slot >= 0 && slot < inputSlotCount) {
-                    var material = MaterialInstance.from(stack);
-                    return material != null && info.acceptsMaterial(material);
-                }
-                return false;
+                // Validation for GUI input and automation lives on the block entity.
+                return slot >= 0 && slot < inputSlotCount;
             }
 
             @Override
@@ -338,6 +362,49 @@ public class AlloyMakerBlockEntity<R extends AlloyRecipe> extends SgContainerBlo
                 return super.extractItem(slot, amount, simulate);
             }
         };
+    }
+
+    private IItemHandler createAutomationItemHandler() {
+        return new IItemHandler() {
+            @Override
+            public int getSlots() {
+                return items.getSlots();
+            }
+
+            @Override
+            public ItemStack getStackInSlot(int slot) {
+                return items.getStackInSlot(slot);
+            }
+
+            @Override
+            public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
+                if (!AlloyMakerBlockEntity.this.canPlaceItem(slot, stack)) {
+                    return stack;
+                }
+
+                return items.insertItem(slot, stack, simulate);
+            }
+
+            @Override
+            public ItemStack extractItem(int slot, int amount, boolean simulate) {
+                return items.extractItem(slot, amount, simulate);
+            }
+
+            @Override
+            public int getSlotLimit(int slot) {
+                return items.getSlotLimit(slot);
+            }
+
+            @Override
+            public boolean isItemValid(int slot, ItemStack stack) {
+                return AlloyMakerBlockEntity.this.canPlaceItem(slot, stack);
+            }
+        };
+    }
+
+    @Override
+    public IItemHandler getItemHandler() {
+        return this.automationItemHandler;
     }
 
     @Override

--- a/src/main/java/net/silentchaos512/gear/block/alloymaker/AlloyMakerContainer.java
+++ b/src/main/java/net/silentchaos512/gear/block/alloymaker/AlloyMakerContainer.java
@@ -102,7 +102,7 @@ public class AlloyMakerContainer extends AbstractContainerMenu {
 
                 slot.onQuickCraft(stack1, stack);
             } else if (index >= inventorySize) {
-                if (isValidIngredient()) {
+                if (isValidIngredient(stack1)) {
                     if (!this.moveItemStackTo(stack1, 0, outputSlot, false)) {
                         // Move from player or hotbar to input slots
                         return ItemStack.EMPTY;
@@ -136,7 +136,12 @@ public class AlloyMakerContainer extends AbstractContainerMenu {
         return stack;
     }
 
-    private boolean isValidIngredient() {
-        return true; // TODO
+    private boolean isValidIngredient(ItemStack stack) {
+        for (int i = 0; i < this.inventory.getContainerSize() - 2; ++i) {
+            if (this.slots.get(i).mayPlace(stack)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

Closes #919 

This fixes alloy makers rejecting valid custom recipe inputs when they are inserted through automation.

Before this change, the GUI and automation used different acceptance rules:

- manual GUI insertion accepted any item in alloy-maker input slots
- automation only accepted stacks that resolved to Silent Gear material inputs

That meant custom `Ingredient`-based recipes such as Azure Electrum could be crafted manually, but pipes / AE2 could not insert inputs like Azure Silver storage blocks or ender pearls.

## Root Cause

`AlloyMakerBlockEntity.canPlaceItem` and the automation-facing `IItemHandler` were validating inputs differently.

- GUI path: permissive input-slot check
- automation path: material-only validation through `MaterialInstance.from(stack)` and `info.acceptsMaterial(...)`
- recipe path: normal `Ingredient.test(stack)` matching

Because of that mismatch, valid custom recipe inputs were blocked before automation could insert them.

## Fix

This PR makes GUI input and automation share the same validator.

An alloy-maker input is now accepted if it is either:

- a valid material input for generic compounding, or
- a valid ingredient for any registered recipe of that alloy maker's recipe type

Implementation details:

- add a shared input validator in `AlloyMakerBlockEntity`
- use that validator from `canPlaceItem` so manual insertion follows the same rules as automation
- expose a filtered automation `IItemHandler` wrapper from `getItemHandler()` so automated insertion follows the same validation logic
- keep the underlying internal inventory handler responsible only for slot layout and extraction rules
- update `AlloyMakerContainer.quickMoveStack` to only shift-click items into alloy-maker inputs when at least one input slot would accept them

## Behavior Change

Examples that should now work through automation:

- Azure Electrum with an Azure Silver block, 2 gold ingots, and 1 ender pearl
- other custom alloy recipes that use non-material `Ingredient` inputs such as blaze powder or magma cream

This also tightens GUI insertion so it matches the real accepted inputs instead of allowing arbitrary junk items into alloy-maker input slots.

## Verification

1. Insert Azure Electrum ingredients through AE2 / pipes and verify the Alloy Forge accepts them.
2. Confirm the same recipe still works through manual GUI insertion.
3. Verify existing custom alloy recipes using non-material ingredients still automate correctly.
4. Verify generic material compounding still accepts normal material inputs.
5. Verify obviously invalid items are rejected by both GUI insertion and automation.
