### PR TITLE
Correct seed item translation keys

### DIFF
--- a/src/main/java/net/silentchaos512/gear/setup/SgItems.java
+++ b/src/main/java/net/silentchaos512/gear/setup/SgItems.java
@@ -1,7 +1,9 @@
 package net.silentchaos512.gear.setup;
 
+import net.minecraft.core.registries.Registries;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemNameBlockItem;
@@ -162,9 +164,9 @@ public final class SgItems {
     public static final DeferredItem<SlingshotAmmoItem> PEBBLE = register("pebble", () -> new SlingshotAmmoItem(baseProps()));
 
     public static final DeferredItem<ItemNameBlockItem> FLAX_SEEDS = register("flax_seeds", () ->
-            new SeedItem(SgBlocks.FLAX_PLANT.get(), baseProps()));
+            new SeedItem(SgBlocks.FLAX_PLANT.get(), baseProps().setId(ResourceKey.create(Registries.ITEM, SilentGear.getId("flax_seeds")))));
     public static final DeferredItem<ItemNameBlockItem> FLUFFY_SEEDS = register("fluffy_seeds", () ->
-            new SeedItem(SgBlocks.FLUFFY_PLANT.get(), baseProps()));
+            new SeedItem(SgBlocks.FLUFFY_PLANT.get(), baseProps().setId(ResourceKey.create(Registries.ITEM, SilentGear.getId("fluffy_seeds")))));
 
     public static final DeferredItem<Item> NETHER_BANANA = register("nether_banana", () ->
             new Item(baseProps()


### PR DESCRIPTION
This updates the flax and fluffy seed registrations so their item properties use the item registry keys rather than the crop block keys. The existing `item.silentgear.flax_seeds` and `item.silentgear.fluffy_seeds` translations can now be used for the seed item names.

Verification:
- `git diff --check`
- Targeted assertions confirmed the seed registrations set `Registries.ITEM` keys for `flax_seeds` and `fluffy_seeds`, and that both item translation keys already exist in `en_us.json`.
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 bash ./gradlew compileJava --no-daemon --stacktrace -Pgpr.username=dummy -Pgpr.token=dummy` was attempted, but the local NeoGradle setup spent the timeout in Minecraft source decompilation before Java compilation completed.