### PR TITLE
Fix/machete cobweb hash crash on machetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Machetes crashing the game the same way swords used to before #879. The fix from that issue was never applied to `GearMacheteItem`, so any machete could still crash a server/client when its Tool component had to be hashed for network sync (e.g. inventory sync after crafting).
+
 ## [26.1.2-4.2.2] - 2026-08-02
 ### Fixed
 - JEI support has been updated

--- a/src/main/java/net/silentchaos512/gear/item/gear/GearMacheteItem.java
+++ b/src/main/java/net/silentchaos512/gear/item/gear/GearMacheteItem.java
@@ -68,7 +68,8 @@ public class GearMacheteItem extends GearSwordItem implements BreakEventHandler,
                 List.of(
                         Tool.Rule.deniesDrops(blocks.getOrThrow(harvestTier.value().incorrectForTool())),
                         Tool.Rule.minesAndDrops(blocks.getOrThrow(getToolBlockSet(gear)), harvestSpeed),
-                        Tool.Rule.minesAndDrops(HolderSet.direct(Holder.direct(Blocks.COBWEB)), 15.0F),
+//                        Tool.Rule.minesAndDrops(HolderSet.direct(Holder.direct(Blocks.COBWEB)), 15.0F),
+                        Tool.Rule.minesAndDrops(blocks.getOrThrow(SgTags.Blocks.SWORD_HIGH_EFFICIENT), 15.0f),
                         Tool.Rule.overrideSpeed(blocks.getOrThrow(BlockTags.SWORD_INSTANTLY_MINES), Float.MAX_VALUE),
                         Tool.Rule.overrideSpeed(blocks.getOrThrow(BlockTags.SWORD_EFFICIENT), 1.5f)
                 ),


### PR DESCRIPTION
Fixes #986. Same fix as #879, but for machetes.

```diff
                        Tool.Rule.minesAndDrops(blocks.getOrThrow(getToolBlockSet(gear)), harvestSpeed),
-                        Tool.Rule.minesAndDrops(HolderSet.direct(Holder.direct(Blocks.COBWEB)), 15.0F),
+//                        Tool.Rule.minesAndDrops(HolderSet.direct(Holder.direct(Blocks.COBWEB)), 15.0F),
+                        Tool.Rule.minesAndDrops(blocks.getOrThrow(SgTags.Blocks.SWORD_HIGH_EFFICIENT), 15.0f),
                        Tool.Rule.overrideSpeed(blocks.getOrThrow(BlockTags.SWORD_INSTANTLY_MINES), Float.MAX_VALUE),
```

My apologies, I had this set to the wrong base earlier then had to step out for work.